### PR TITLE
fix DeleteWithConfirmButton

### DIFF
--- a/src/components/button/DeleteWithConfirmButton.js
+++ b/src/components/button/DeleteWithConfirmButton.js
@@ -31,9 +31,9 @@ const sanitizeRestProps = ({
 
 const StyledButton = styled(Button)`
   ${props => `
-    color: ${props.theme.$red} 
+    color: ${props.theme.$red}
     &:hover {
-      background-color: ${Color(props.theme.$red.fade(0.12).toString())}
+      background-color: ${Color(props.theme.$red).fade(0.12).toString()}
     }
   `}
 `;

--- a/src/components/button/DeleteWithConfirmButton.js
+++ b/src/components/button/DeleteWithConfirmButton.js
@@ -31,7 +31,7 @@ const sanitizeRestProps = ({
 
 const StyledButton = styled(Button)`
   ${props => `
-    color: ${props.theme.$red}
+    color: ${props.theme.$red};
     &:hover {
       background-color: ${Color(props.theme.$red).fade(0.12).toString()}
     }


### PR DESCRIPTION
Fix error when using Edit component with undoable={false}.

The error message is: `TypeError: props.theme.$red.fade is not a function`. Error occurs due to DeleteWithConfirmButton having a small mistake in the code.

I have fixed the issue. Patch included in this PR.

## ra-ui

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/bootstrap-styled/ra-ui/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [ ] You have followed our [**contributing guidelines**](https://github.com/bootstrap-styled/ra-ui/blob/master/.github/CONTRIBUTING.md)
- [ ] Double-check your branch is based on `dev` and targets `dev`
- [ ] Your are doing semantic commit message using [commitizen](https://github.com/commitizen/cz-cli) and our [commit message convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/bootstrap-styled/ra-ui/blob/master/LICENSE.md).
